### PR TITLE
Test-RDMA update parameters to diskspd

### DIFF
--- a/Diagnostics/Test-Rdma.ps1
+++ b/Diagnostics/Test-Rdma.ps1
@@ -280,7 +280,7 @@ if ($OutputLevel -eq 2)
 $ScriptBlock = {
     param($RemoteIpAddress, $PathToDiskspd, $TargetFileName) 
     cd $PathToDiskspd
-    .\diskspd.exe -b4K -c10G -t4 -o16 -d100000 -L -Sr -d30 $TargetFileName
+    .\diskspd.exe -b1M -c2M -d30 -ft -L -o32 -r -Sr -t8 -w0 $TargetFileName
 }
       
 $thisJob = Start-Job $ScriptBlock -ArgumentList $RemoteIpAddress,$PathToDiskspd,$TargetFileName


### PR DESCRIPTION
Updated parameters to invocation of diskspd to more thoroughly test RDMA network performance.
New parameters -b1M -c2M -d30 -ft -L -o32 -r -Sr -t8 -w0 
-b1M Block size in MiB
-c2M File size in MiB
-d30 Duration in seconds, not including cool-down or warm-up time
-ft Open file with FILE_ATTRIBUTE_TEMPORARY access hints
-L Measure latency statistics
-o32 Number of outstanding I/O requests per-target per-thread
-r Random I/O
-Sr Disable local caching for remote file systems. This leaves the remote system's cache enabled.
-t8	Number of threads per target
-w0 Percentage of write requests to issue

References:
https://unhandled.wordpress.com/2016/07/20/madness-testing-smb-direct-network-throughput-with-diskspd/